### PR TITLE
Removed localization prefix from string inititalizers

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -120,17 +120,17 @@ wxEND_EVENT_TABLE()
 wxIMPLEMENT_APP(MyApp);
 
 static const wxCmdLineEntryDesc g_cmdLineDesc[] = {
-    {wxCMD_LINE_SWITCH, _("h"), _("help"), _("displays command line options"),
+    {wxCMD_LINE_SWITCH, "h", "help", "displays command line options",
      wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP},
-    {wxCMD_LINE_SWITCH, _("f"), _("force"), _("overwrite any existing file"),
+    {wxCMD_LINE_SWITCH, "f", "force", "overwrite any existing file",
      wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
-    {wxCMD_LINE_SWITCH, _("l"), _("lib"), _("creates LIB library file"),
+    {wxCMD_LINE_SWITCH, "l", "lib", "creates LIB library file",
      wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
-    {wxCMD_LINE_SWITCH, _("s"), _("symbol"), _("creates ASY symbol file"),
+    {wxCMD_LINE_SWITCH, "s", "symbol", "creates ASY symbol file",
      wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
-    {wxCMD_LINE_SWITCH, _("q"), _("quiet"),
-     _("disables the GUI (for command line only usage)")},
-    {wxCMD_LINE_PARAM, _(""), _(""), _("file name"), wxCMD_LINE_VAL_STRING,
+    {wxCMD_LINE_SWITCH, "q", "quiet",
+     "disables the GUI (for command line only usage)"},
+    {wxCMD_LINE_PARAM, "", "", "file name", wxCMD_LINE_VAL_STRING,
      wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE},
 
     wxCMD_LINE_DESC_END};


### PR DESCRIPTION
Prefixing strings with _() declares them as localizable in wx and therefore automatically of type wxString. 

On the one hand I don't think this is stricly necessary (are you planning to add translations?), on the other hand on some systems (e.g. openSUSE) wxString is defined as Unicode and therefore the strings aren't easily convertable to char*. This leads to compile errors:

henning@watson:~/src/s2spice/build> cmake --build . --config Release
[ 25%] Building CXX object CMakeFiles/SObject.dir/SObject.cpp.o
[ 50%] Linking CXX static library libSObject.a
[ 50%] Built target SObject
[ 75%] Building CXX object CMakeFiles/s2spice.dir/main.cpp.o
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
     wxCMD_LINE_DESC_END};
                        ^
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
/home/henning/src/s2spice/main.cpp:136:24: error: cannot convert ‘const wxString’ to ‘const char*’ in initialization
gmake[2]: *** [CMakeFiles/s2spice.dir/build.make:76: CMakeFiles/s2spice.dir/main.cpp.o] Fehler 1
gmake[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/s2spice.dir/all] Fehler 2
gmake: *** [Makefile:91: all] Fehler 2
